### PR TITLE
Adding possibility to enable custom pin colors to the map meeting events

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/map.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map.js.es6
@@ -40,9 +40,14 @@ const addMarkers = (markersData, markerClusters, map) => {
   const bounds = new L.LatLngBounds(markersData.map((markerData) => [markerData.latitude, markerData.longitude]));
 
   markersData.forEach((markerData) => {
+    let fillColor = window.Decidim.mapConfiguration.markerColor;
+    if (typeof(markerData.markerColor) != "undefined" ) {
+        fillColor = markerData.markerColor;
+    }
+
     let marker = L.marker([markerData.latitude, markerData.longitude], {
       icon: new L.DivIcon.SVGIcon.DecidimIcon({
-        fillColor: window.Decidim.mapConfiguration.markerColor
+        fillColor: fillColor
       }),
       keyboard: true,
       title: markerData.title

--- a/decidim-core/lib/decidim/authorable.rb
+++ b/decidim-core/lib/decidim/authorable.rb
@@ -31,6 +31,27 @@ module Decidim
       def normalized_author
         user_group || author
       end
+      
+      # Public: Checks whether the resource is official or not.
+      #
+      # Returns a boolean.
+      def official?
+        decidim_author_type == Decidim::Organization.name
+      end
+
+      # Public: Checks whether the resource is created by a or not.
+      #
+      # Returns a boolean.
+      def group?
+        decidim_user_group_id.present?
+      end
+
+      # Public: Checks whether the resource created by an user
+      #
+      # Returns a boolean.
+      def citizen?
+        !(group? || official?)
+      end
 
       private
 

--- a/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
@@ -20,8 +20,19 @@ module Decidim
                                                                icon: icon("meetings", width: 40, height: 70, remove_icon_class: true),
                                                                location: translated_attribute(meeting.location),
                                                                locationHints: decidim_html_escape(translated_attribute(meeting.location_hints)),
-                                                               link: resource_locator(meeting).path)
+                                                               link: resource_locator(meeting).path,
+                                                               markerColor: event_pin_color(meeting)
+          )
         end
+      end
+
+      def event_pin_color(meeting)
+        component = meeting.component
+        primary_color = component.organization.colors["primary"]
+
+        return component.settings.official_map_pin_color.presence || primary_color if meeting.official?
+        return component.settings.user_group_map_pin_color.presence || primary_color if meeting.group?
+        component.settings.citizen_map_pin_color.presence || primary_color
       end
     end
   end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -85,6 +85,9 @@ en:
             default_registration_terms: Default registration terms
             enable_pads_creation: Enable pads creation
             resources_permissions_enabled: Actions permissions can be set for each meeting
+            citizen_map_pin_color: Pin color for Citizen generated events
+            official_map_pin_color: Pin color for Official generated events
+            user_group_map_pin_color: Pin color for Group generated events
           step:
             announcement: Announcement
             comments_blocked: Comments blocked

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -54,6 +54,9 @@ Decidim.register_component(:meetings) do |component|
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :enable_pads_creation, type: :boolean, default: false
+    settings.attribute :citizen_map_pin_color, type: :string
+    settings.attribute :official_map_pin_color, type: :string
+    settings.attribute :user_group_map_pin_color, type: :string
   end
 
   component.settings(:step) do |settings|


### PR DESCRIPTION
#### :tophat: What? Why?


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
