### PR TITLE
Adding possibility to enable custom pin colors to the map meeting events

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/map.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map.js.es6
@@ -40,9 +40,13 @@ const addMarkers = (markersData, markerClusters, map) => {
   const bounds = new L.LatLngBounds(markersData.map((markerData) => [markerData.latitude, markerData.longitude]));
 
   markersData.forEach((markerData) => {
+    let fillColor = window.Decidim.mapConfiguration.markerColor;
+    if (typeof(markerData.markerColor) != "undefined" ) {
+      fillColor = markerData.markerColor;
+    }
     let marker = L.marker([markerData.latitude, markerData.longitude], {
       icon: new L.DivIcon.SVGIcon.DecidimIcon({
-        fillColor: window.Decidim.mapConfiguration.markerColor
+        fillColor: fillColor
       }),
       keyboard: true,
       title: markerData.title

--- a/decidim-core/lib/decidim/authorable.rb
+++ b/decidim-core/lib/decidim/authorable.rb
@@ -39,6 +39,20 @@ module Decidim
         decidim_author_type == Decidim::Organization.name
       end
 
+      # Public: Checks whether the resource is created by a or not.
+      #
+      # Returns a boolean.
+      def group?
+        decidim_user_group_id.present?
+      end
+
+      # Public: Checks whether the resource created by an user
+      #
+      # Returns a boolean.
+      def citizen?
+        !(group? || official?)
+      end
+
       private
 
       def verified_user_group

--- a/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
@@ -20,8 +20,19 @@ module Decidim
                                                                icon: icon("meetings", width: 40, height: 70, remove_icon_class: true),
                                                                location: translated_attribute(meeting.location),
                                                                locationHints: decidim_html_escape(translated_attribute(meeting.location_hints)),
-                                                               link: resource_locator(meeting).path)
+                                                               link: resource_locator(meeting).path,
+                                                               markerColor: event_pin_color(meeting)
+          )
         end
+      end
+
+      def event_pin_color(meeting)
+        component = meeting.component
+        primary_color = component.organization.colors["primary"]
+
+        return component.settings.official_map_pin_color.presence || primary_color if meeting.official?
+        return component.settings.user_group_map_pin_color.presence || primary_color if meeting.group?
+        component.settings.citizen_map_pin_color.presence || primary_color
       end
     end
   end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -89,6 +89,9 @@ en:
             default_registration_terms: Default registration terms
             enable_pads_creation: Enable pads creation
             resources_permissions_enabled: Actions permissions can be set for each meeting
+            citizen_map_pin_color: Pin color for Citizen generated events
+            official_map_pin_color: Pin color for Official generated events
+            user_group_map_pin_color: Pin color for Group generated events
           step:
             announcement: Announcement
             comments_blocked: Comments blocked

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -57,6 +57,9 @@ Decidim.register_component(:meetings) do |component|
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :enable_pads_creation, type: :boolean, default: false
     settings.attribute :creation_enabled_for_participants, type: :boolean, default: false
+    settings.attribute :citizen_map_pin_color, type: :string
+    settings.attribute :official_map_pin_color, type: :string
+    settings.attribute :user_group_map_pin_color, type: :string
   end
 
   component.settings(:step) do |settings|


### PR DESCRIPTION
#### :tophat: Allow the Administrator user to configure the pin colors on the maps in decidim, by configuring the #RGB code on the component page. If the colors are not set in the admin, then the default color is used. 

### :camera: Screenshots (optional)
Admin section:
![image](https://user-images.githubusercontent.com/105683/92562301-6905a480-f27e-11ea-8c09-680866513539.png)

End result (please ignore the colors as they can be set from admin):
![image](https://user-images.githubusercontent.com/105683/92562351-80449200-f27e-11ea-8194-bb01b1f3af74.png)


