### PR TITLE
Adding cell instrumentation to display rails-cells information output

### DIFF
--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -97,9 +97,10 @@ module Decidim
     #
     # Renders the cell contents.
     def cell(name, model, options = {}, &block)
-      options = { context: { current_user: current_user } }.deep_merge(options)
-
-      super(name, model, options, &block)
+      instrument(:cell, identifier: name) do |_payload|
+        options = { context: { current_user: current_user } }.deep_merge(options)
+        super(name, model, options, &block).to_s
+      end
     end
 
     # Public: Builds the URL for the step Call To Action. Takes URL params
@@ -117,6 +118,12 @@ module Decidim
         [base_url, "/", process.active_step.cta_path, "?", params].join("")
       else
         [base_url, "/", process.active_step.cta_path].join("")
+      end
+    end
+
+    def instrument(name, **options)
+      ActiveSupport::Notifications.instrument("render_#{name}.action_view", options) do |payload|
+        yield payload
       end
     end
   end

--- a/decidim-core/config/initializers/active_support.rb
+++ b/decidim-core/config/initializers/active_support.rb
@@ -1,0 +1,5 @@
+ActiveSupport::Notifications.subscribe "render_cell.action_view" do |name, started, finished, unique_id, data|
+  event = ActiveSupport::Notifications::Event.new(name, started, finished, unique_id, data)
+  message = "  Rendered cell #{event.payload[:identifier]} (#{event.duration.round(1)}ms)"
+  Rails.logger.info(message)
+end


### PR DESCRIPTION
#### :tophat: Adding instrumentation method to display the time rails spends rendering a cell. Now the logs will display following information.
```
I, [2020-09-13T20:23:04.004205 #1]  INFO -- : [9a54062a-2070-4300-a96a-e3ab991e9156]   Rendered cell decidim/meetings/meeting_s (3.5ms)
I, [2020-09-13T20:23:04.005733 #1]  INFO -- : [9a54062a-2070-4300-a96a-e3ab991e9156]   Rendered cell decidim/meetings/meeting_s (1.1ms)
I, [2020-09-13T20:23:04.008962 #1]  INFO -- : [9a54062a-2070-4300-a96a-e3ab991e9156]   Rendered cell decidim/meetings/content_blocks/upcoming_events (16.6ms)
```


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
